### PR TITLE
Add a handful of recent papers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,32 @@
 
 Currently very incomplete.  [Pull requests](https://github.com/metaocaml/metaocaml-bibliography/pulls) welcome!  Note: end a line with two spaces to force a line break.
 
+#### 2023
+
+* **MetaOCaml Theory and Implementation** (OCaml 2023)  
+  ([paper](https://icfp23.sigplan.org/details?action-call-with-get-request-type=1&3bc77d800d874af6a3c7584474282f65action_17426506610a8da7421c2b887404d1d1d86a0d5ede9=1&__ajax_runtime_request__=1&context=icfp-2023&track=ocaml-2023-papers&urlKey=3&decoTitle=MetaOCaml-Theory-and-Implementation))  
+  by Oleg Kiselyov
+
+* **Safe and efficient generic functions with MacoCaml** (OCaml 2023)  
+  ([paper](https://www.cl.cam.ac.uk/~jdy22/papers/safe-and-efficient-generic-functions-with-macocaml.pdf))
+  ([code](https://gist.github.com/yallop/34f2adf63d0c0b82ab849b7fda7ff3ee))  
+  by Dmitrij Szamozvancev, Leo White, Ningning Xie and Jeremy Yallop
+
+* **MacoCaml: Staging Composable and Compilable Macros** (ICFP 2023)  
+  ([paper](https://www.cl.cam.ac.uk/~jdy22/papers/macocaml-staging-composable-and-compilable-macros.pdf))  
+  by Ningning Xie, Leo White, Olivier Nicole and Jeremy Yallop
+
+* **flap: A Deterministic Parser with Fused Lexing** (PLDI 2023)  
+  ([paper](https://www.cl.cam.ac.uk/~jdy22/papers/flap-a-deterministic-parser-with-fused-lexing.pdf))
+  ([code](https://github.com/yallop/ocaml-flap))  
+  by Jeremy Yallop, Ningning Xie and Neel Krishnaswami
+
 #### 2022
+
+* **Highest-performance Stream Processing** (OCaml 2022)  
+  ([paper](https://okmij.org/ftp/meta-programming/strymonasv2-intro.pdf))
+  ([code](https://github.com/strymonas/strymonas-ocaml/))  
+  by Oleg Kiselyov, Tomoaki Kobayashi, Aggelos Biboudis, Nick Palladinos
 
 * **Unified Program Generation and Verification: A Case Study on Number-Theoretic Transform** (FLOPS 2022)  
   ([paper](http://www.cs.tsukuba.ac.jp/~kam/papers/flops2022-author-version.pdf))

--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ Currently very incomplete.  [Pull requests](https://github.com/metaocaml/metaoca
 #### 2004
 
 * **Binding-Time Analysis for MetaML via Type Inference and Constraint Solving** (TACAS 2004)  
-  ([paper](https://pdfs.semanticscholar.org/9bc6/954a68e96ef09750b146879c4cf579aca206.pdf))
+  ([paper](https://link.springer.com/content/pdf/10.1007/978-3-540-24730-2_22.pdf))
   ([BibTeX](https://dblp.uni-trier.de/rec/bibtex/conf/tacas/LingerS04))  
   by Nathan Linger and Tim Sheard
 
@@ -487,7 +487,7 @@ Currently very incomplete.  [Pull requests](https://github.com/metaocaml/metaoca
   by Cristiano Calcagno, Walid Taha, Liwen Huang and Xavier Leroy
 
 * **Staged Notational Definitions** (GPCE 2003)  
-  ([paper](https://cs.appstate.edu/~johannp/gpce03.pdf))
+  ([paper](https://libres.uncg.edu/ir/asu/f/Johann_Patricia_2003_Staged%20Notational%20Definitions.pdf))
   ([BibTeX](https://dblp.uni-trier.de/rec/bibtex/conf/gpce/TahaJ03))  
   by Walid Taha and Patricia Johann
 
@@ -581,7 +581,7 @@ Currently very incomplete.  [Pull requests](https://github.com/metaocaml/metaoca
   by Tim Sheard
 
 * **Multi-Stage Programming: Axiomatization and Type-Safety** (ICALP 1998)  
-  ([paper](https://pdfs.semanticscholar.org/e6b9/c89f9d49e81b89cb15b988f1ade86f73ed63.pdf))
+  ([paper](https://github.com/maroneal/www/raw/master/publications/conference/icalp98.pdf))
   ([BibTeX](https://dblp.uni-trier.de/rec/bibtex/conf/icalp/TahaBS98))  
   by Walid Taha, Zine-El-Abidine Benaissa and Tim Sheard
 


### PR DESCRIPTION
* **MetaOCaml Theory and Implementation** (OCaml 2023)  
  ([paper](https://icfp23.sigplan.org/details?action-call-with-get-request-type=1&3bc77d800d874af6a3c7584474282f65action_17426506610a8da7421c2b887404d1d1d86a0d5ede9=1&__ajax_runtime_request__=1&context=icfp-2023&track=ocaml-2023-papers&urlKey=3&decoTitle=MetaOCaml-Theory-and-Implementation))  
  by Oleg Kiselyov

* **Safe and efficient generic functions with MacoCaml** (OCaml 2023)  
  ([paper](https://www.cl.cam.ac.uk/~jdy22/papers/safe-and-efficient-generic-functions-with-macocaml.pdf)) ([code](https://gist.github.com/yallop/34f2adf63d0c0b82ab849b7fda7ff3ee))  
  by Dmitrij Szamozvancev, Leo White, Ningning Xie and Jeremy Yallop

* **MacoCaml: Staging Composable and Compilable Macros** (ICFP 2023)  
  ([paper](https://www.cl.cam.ac.uk/~jdy22/papers/macocaml-staging-composable-and-compilable-macros.pdf))  
  by Ningning Xie, Leo White, Olivier Nicole and Jeremy Yallop

* **flap: A Deterministic Parser with Fused Lexing** (PLDI 2023)  
  ([paper](https://www.cl.cam.ac.uk/~jdy22/papers/flap-a-deterministic-parser-with-fused-lexing.pdf)) ([code](https://github.com/yallop/ocaml-flap))  
  by Jeremy Yallop, Ningning Xie and Neel Krishnaswami

* **Highest-performance Stream Processing** (OCaml 2022)  
  ([paper](https://okmij.org/ftp/meta-programming/strymonasv2-intro.pdf)) ([code](https://github.com/strymonas/strymonas-ocaml/))  
  by Oleg Kiselyov, Tomoaki Kobayashi, Aggelos Biboudis, Nick Palladinos
